### PR TITLE
Remove dedupe_path from build script

### DIFF
--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -24,29 +24,6 @@ else
     autobuild="$AUTOBUILD"
 fi
 
-dedupe_path ()
-{
-    # We've observed some weird failures in which the PATH is too big to be
-    # passed to a child process! When that gets munged, we start seeing errors
-    # like failing to understand the 'nmake' command. Thing is, by this point
-    # in the script we've acquired a shocking number of duplicate entries.
-    # Dedup the PATH using Python's OrderedDict, which preserves the order in
-    # which you insert keys.
-    # We find that some of the Visual Studio PATH entries appear both with and
-    # without a trailing slash, which is pointless. Strip those off and dedup
-    # what's left.
-    # Pass the existing PATH as an explicit argument rather than reading it
-    # from the environment to bypass the fact that cygwin implicitly converts
-    # PATH to Windows form when running a native executable. Since we're
-    # setting bash's PATH, leave everything in cygwin form. That means
-    # splitting and rejoining on ':' rather than on os.pathsep, which on
-    # Windows is ';'.
-    # Use python -u, else the resulting PATH will end with a spurious '\r'.
-    export PATH="$(python -u -c "import sys
-from collections import OrderedDict
-print(':'.join(OrderedDict((dir.rstrip('/'), 1) for dir in sys.argv[1].split(':'))))" "$PATH")"
-}
-
 stage="$(pwd)/stage"
 
 # load autobuild provided shell functions and variables
@@ -58,12 +35,6 @@ pushd "$ICU4C_SOURCE_DIR"
     case "$AUTOBUILD_PLATFORM" in
         windows*)
             load_vsvars
-
-            dedupe_path
-
-            export PATH="$(python -u -c "import sys
-print(':'.join(d for d in sys.argv[1].split(':')
-if not any(frag in d for frag in ('CommonExtensions', 'VSPerfCollectionTools', 'Team Tools'))))" "$PATH")"
 
             # According to the icu build instructions for Windows,
             # runConfigureICU doesn't work for the Microsoft build tools, so


### PR DESCRIPTION
Autobuild 3.7.0 fixes long paths, so this is longer needed.