### PR TITLE
Debug why LL's build runner creates a broken (seemingly non PIC) static lib when compiling Linux

### DIFF
--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -124,8 +124,18 @@ pushd "$ICU4C_SOURCE_DIR"
                 # HACK: Break format layout so boost can find the library.
                 ./runConfigureICU Linux $common_options --libdir=${stage}/lib/
 
-                make -j$(nproc)
+                make
                 make install
+
+                echo ****DEBUG OUTPUT****
+                echo ""
+                objdump -x common/utf_impl.ao | grep utf8_countTrailBytes_48
+                echo ""
+                ld -v
+                echo ""
+                gcc -v
+                echo ""
+                echo ****END DEBUG OUTPUT****
             popd
 
             # populate version_file


### PR DESCRIPTION
Debug the strange behavior of some GHA (under my account) runs creati…ng a 'good' library with -fPIC enabled symbols, while others (under the LL org) create a 'bad' library as if it was never compiled with -fPIC.

Known so far:
- Logs from the GHA builds always show -fPIC passed to the compiler.
- GHA builds from LL create no relocatable library sections

Plan:
- Disable parallel building, just to see if that makes any difference
- Output GCC and ld version
- objdump -x to verify the generated symbols in utf_impl.ao